### PR TITLE
Add signal handling

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -24,6 +28,14 @@ var serverCommand = &cobra.Command{
 		s := server.NewGRPCServer(net.NetAddress{
 			Port: serverPort,
 		})
+
+		sigs := make(chan os.Signal, 1)
+		go func() {
+			signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+			log.Debugf("Received signal %s", <-sigs)
+
+			s.Stop()
+		}()
 
 		err := s.Start()
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -41,3 +41,8 @@ func (s GRPCServer) Start() error {
 
 	return nil
 }
+
+func (s GRPCServer) Stop() {
+	log.Info("Stopping server")
+	s.gs.Stop()
+}


### PR DESCRIPTION
This will add signals handling in server mode for `SIGINT` and `SIGTERM`.

With this the gRPC server gets stopped gracefully and handles connection dropping itself rather than just letting it die.

Fixes #1 