### PR TITLE
Make logger a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # Ping Pong gRPC
 
-[![Docker Repository on
-Quay](https://quay.io/repository/denderello/ping-pong-grpc/status "Docker
-Repository on Quay")](https://quay.io/repository/denderello/ping-pong-grpc)
-
-[![Go Report Card](https://goreportcard.com/badge/denderello/ping-pong-grpc "Go Report
-Card")](https://goreportcard.com/report/denderello/ping-pong-grpc)
+[![Docker Repository on Quay](https://quay.io/repository/denderello/ping-pong-grpc/status "Docker Repository on Quay")](https://quay.io/repository/denderello/ping-pong-grpc)
+[![Go Report Card](https://goreportcard.com/badge/denderello/ping-pong-grpc "Go Report Card")](https://goreportcard.com/report/denderello/ping-pong-grpc)
 
 A little ping pong program that talks via gRPC.
 

--- a/client/client.go
+++ b/client/client.go
@@ -3,34 +3,43 @@ package client
 import (
 	"fmt"
 
+	"github.com/denderello/ping-pong-grpc/log"
 	"github.com/denderello/ping-pong-grpc/net"
 	"github.com/denderello/ping-pong-grpc/pingpong"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
-type GRPCClient struct {
-	a  net.Addresser
-	cc *grpc.ClientConn
-	ci pingpong.PingPongClient
+type GRPCClientConfig struct {
+	Logger  log.Logger
+	Address net.Addresser
 }
 
-func NewGRPCClient(a net.Addresser) (GRPCClient, error) {
-	log.Debugf("Establishing connection to %s", a.Address())
-	cc, err := grpc.Dial(a.Address(), grpc.WithInsecure())
+type GRPCClient struct {
+	logger         log.Logger
+	address        net.Addresser
+	conn           *grpc.ClientConn
+	pingPongClient pingpong.PingPongClient
+}
+
+func NewGRPCClient(conf GRPCClientConfig) (GRPCClient, error) {
+	conf.Logger.Info("Starting in client mode")
+
+	conf.Logger.Debugf("Establishing connection to %s", conf.Address.Address())
+	c, err := grpc.Dial(conf.Address.Address(), grpc.WithInsecure())
 	if err != nil {
-		return GRPCClient{}, errors.Wrap(err, fmt.Sprintf("Could not connect to %s", a.Address()))
+		return GRPCClient{}, errors.Wrap(err, fmt.Sprintf("Could not connect to %s", conf.Address.Address()))
 	}
 
 	return GRPCClient{
-		a:  a,
-		cc: cc,
-		ci: pingpong.NewPingPongClient(cc),
+		logger:         conf.Logger,
+		address:        conf.Address,
+		conn:           c,
+		pingPongClient: pingpong.NewPingPongClient(c),
 	}, nil
 }
 
 func (c GRPCClient) Close() {
-	c.cc.Close()
+	c.conn.Close()
 }

--- a/client/ping.go
+++ b/client/ping.go
@@ -6,26 +6,25 @@ import (
 
 	"github.com/denderello/ping-pong-grpc/pingpong"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
 func (c GRPCClient) Ping(cycleMode bool, cycleSleepDuration time.Duration) error {
-	log.Debugf("Running with cycle mode: %t and sleep duration: %s", cycleMode, cycleSleepDuration)
+	c.logger.Debugf("Running with cycle mode: %t and sleep duration: %s", cycleMode, cycleSleepDuration)
 
 	for {
 		req := &pingpong.Ping{Message: "ping"}
 
-		log.Infof("Sending message to server: %s", req.Message)
-		log.Debugf("Sending request to server: %#v", req)
-		resp, err := c.ci.SendPing(context.Background(), req)
+		c.logger.Infof("Sending message to server: %s", req.Message)
+		c.logger.Debugf("Sending request to server: %#v", req)
+		resp, err := c.pingPongClient.SendPing(context.Background(), req)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Did not receive a pong."))
 		}
-		log.Infof("Received message from server: %s", resp.Message)
+		c.logger.Infof("Received message from server: %s", resp.Message)
 
-		log.Debugf("Received response from server: %#v", resp)
+		c.logger.Debugf("Received response from server: %#v", resp)
 
 		if !cycleMode {
 			break

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -6,7 +6,6 @@ import (
 	"github.com/denderello/ping-pong-grpc/client"
 	"github.com/denderello/ping-pong-grpc/net"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +28,7 @@ var clientCommand = &cobra.Command{
 	Short: "Run pingpong in client mode",
 	Long:  `Run pingpong in client mode and send ping messages to a pingpong server`,
 	Run: func(cmd *cobra.Command, args []string) {
-		l := logrus.StandardLogger()
+		l := newLogger()
 
 		c, err := client.NewGRPCClient(client.GRPCClientConfig{
 			Logger: l,

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/denderello/ping-pong-grpc/client"
 	"github.com/denderello/ping-pong-grpc/net"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -29,21 +29,24 @@ var clientCommand = &cobra.Command{
 	Short: "Run pingpong in client mode",
 	Long:  `Run pingpong in client mode and send ping messages to a pingpong server`,
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Info("Starting in client mode")
+		l := logrus.StandardLogger()
 
-		c, err := client.NewGRPCClient(net.NetAddress{
-			Host: clientHost,
-			Port: clientPort,
+		c, err := client.NewGRPCClient(client.GRPCClientConfig{
+			Logger: l,
+			Address: net.NetAddress{
+				Host: clientHost,
+				Port: clientPort,
+			},
 		})
 		if err != nil {
-			log.Fatal(err)
+			l.Fatal(err)
 		}
 
 		defer c.Close()
 
 		err = c.Ping(clientCycleMode, clientCycleSleepDuration)
 		if err != nil {
-			log.Fatal(err)
+			l.Fatal(err)
 		}
 	},
 }

--- a/cmd/pingpong.go
+++ b/cmd/pingpong.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -26,21 +26,8 @@ var PingPongCommand = &cobra.Command{
 	Short: "Pingpong is a simple request/response test tool",
 	Long:  `Pingpong can run in server and client mode.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		switch logLevel {
-		case "debug":
-			log.SetLevel(log.DebugLevel)
-		case "info":
-			log.SetLevel(log.InfoLevel)
-		case "warn":
-			log.SetLevel(log.WarnLevel)
-		case "error":
-			log.SetLevel(log.ErrorLevel)
-		case "fatal":
-			log.SetLevel(log.FatalLevel)
-		case "panic":
-			log.SetLevel(log.PanicLevel)
-		default:
-			log.Fatalf("Cannot use unsupported log level %s.", logLevel)
+		if _, err := logrus.ParseLevel(logLevel); err != nil {
+			logrus.Fatal(err)
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,7 +5,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/denderello/ping-pong-grpc/net"
@@ -25,21 +25,26 @@ var serverCommand = &cobra.Command{
 	Short: "Run pingpong in server mode",
 	Long:  `Run pingpong in server mode and wait for ping message to respond with a pong.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		s := server.NewGRPCServer(net.NetAddress{
-			Port: serverPort,
+		l := logrus.StandardLogger()
+
+		s := server.NewGRPCServer(server.GRPCServerConfig{
+			Logger: l,
+			Address: net.NetAddress{
+				Port: serverPort,
+			},
 		})
 
 		sigs := make(chan os.Signal, 1)
 		go func() {
 			signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-			log.Debugf("Received signal %s", <-sigs)
+			l.Debugf("Received signal %s", <-sigs)
 
 			s.Stop()
 		}()
 
 		err := s.Start()
 		if err != nil {
-			log.Fatal(err)
+			l.Fatal(err)
 		}
 	},
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,7 +5,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/denderello/ping-pong-grpc/net"
@@ -25,7 +24,7 @@ var serverCommand = &cobra.Command{
 	Short: "Run pingpong in server mode",
 	Long:  `Run pingpong in server mode and wait for ping message to respond with a pong.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		l := logrus.StandardLogger()
+		l := newLogger()
 
 		s := server.NewGRPCServer(server.GRPCServerConfig{
 			Logger: l,

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -2,8 +2,16 @@ package cmd
 
 import (
 	"fmt"
+
+	"github.com/denderello/ping-pong-grpc/log"
+
+	"github.com/Sirupsen/logrus"
 )
 
 func printProjectVersion() {
 	fmt.Printf("PingPong %s (%s)\n", projectVersion, projectCommit)
+}
+
+func newLogger() log.Logger {
+	return logrus.StandardLogger()
 }

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,21 @@
+package log
+
+type Logger interface {
+	Debug(v ...interface{})
+	Debugf(format string, v ...interface{})
+
+	Info(v ...interface{})
+	Infof(format string, v ...interface{})
+
+	Warn(v ...interface{})
+	Warnf(format string, v ...interface{})
+
+	Error(v ...interface{})
+	Errorf(format string, v ...interface{})
+
+	Fatal(v ...interface{})
+	Fatalf(format string, v ...interface{})
+
+	Panic(v ...interface{})
+	Panicf(format string, v ...interface{})
+}


### PR DESCRIPTION
This will turn logrus into a dependency rather than using it globally in all packages that need logging.